### PR TITLE
Ensure successful compilation on gcc 8.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+srec2hex

--- a/srec2hex.c
+++ b/srec2hex.c
@@ -60,7 +60,7 @@ const char *	kSrec2hexVersion = "0.2";
 int
 main(int argc, char *  argv[])
 {
-	uint64_t	codeAddress;
+	uint64_t	codeAddress = 0;
 
 
 	while (1)


### PR DESCRIPTION
On that version of gcc there is a warning for uninitialized variables,
which is then turned into an error with -Werror preventing
compilation. This just silences the warning.